### PR TITLE
fix order of closing socket-connection to avoid crashes

### DIFF
--- a/include/libKitsunemimiNetwork/tcp/tcp_socket.h
+++ b/include/libKitsunemimiNetwork/tcp/tcp_socket.h
@@ -30,6 +30,7 @@ public:
     TcpSocket(const std::string &address,
               const uint16_t port,
               const std::string &threadName);
+    ~TcpSocket();
 
     bool initClientSide(ErrorContainer &error);
 

--- a/include/libKitsunemimiNetwork/unix/unix_domain_socket.h
+++ b/include/libKitsunemimiNetwork/unix/unix_domain_socket.h
@@ -25,6 +25,7 @@ class UnixDomainSocket
 public:
     UnixDomainSocket(const std::string &socketFile,
                      const std::string &threadName);
+    ~UnixDomainSocket();
 
     bool initClientSide(ErrorContainer &error);
 

--- a/src/abstract_socket.cpp
+++ b/src/abstract_socket.cpp
@@ -26,10 +26,7 @@ AbstractSocket::AbstractSocket(const std::string &threadName)
 /**
  * @brief destructor, which close the socket before deletion
  */
-AbstractSocket::~AbstractSocket()
-{
-    closeSocket();
-}
+AbstractSocket::~AbstractSocket() {}
 
 /**
  * @brief get socket-type

--- a/src/tcp/tcp_socket.cpp
+++ b/src/tcp/tcp_socket.cpp
@@ -33,6 +33,14 @@ TcpSocket::TcpSocket(const std::string &address,
 }
 
 /**
+ * @brief destructor
+ */
+TcpSocket::~TcpSocket()
+{
+    closeSocket();
+}
+
+/**
  * @brief init socket on client-side
  *
  * @param error reference for error-output

--- a/src/tls_tcp/tls_tcp_socket.cpp
+++ b/src/tls_tcp/tls_tcp_socket.cpp
@@ -67,6 +67,7 @@ TlsTcpSocket::TlsTcpSocket(const int socketFd,
  */
 TlsTcpSocket::~TlsTcpSocket()
 {
+    closeSocket();
     cleanupOpenssl();
 }
 

--- a/src/unix/unix_domain_socket.cpp
+++ b/src/unix/unix_domain_socket.cpp
@@ -30,6 +30,14 @@ UnixDomainSocket::UnixDomainSocket(const std::string &socketFile,
 }
 
 /**
+ * @brief destructor
+ */
+UnixDomainSocket::~UnixDomainSocket()
+{
+    closeSocket();
+}
+
+/**
  * @brief init socket on client-side
  *
  * @param error reference for error-output


### PR DESCRIPTION
## Description

fix order of closing socket-connection to avoid crashes

## Related Issues

#84 

## How it was tested?

- ci-pipeline
